### PR TITLE
Upgrade to SonarQube 5.1.2 and remove outdated configs

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 ROOT=$OPENSHIFT_DATA_DIR
-SONAR_VERSION=4.1.1
+SONAR_VERSION=5.1.2
 
 if [[ $OPENSHIFT_POSTGRESQL_DB_URL ]]
 then
@@ -15,15 +15,13 @@ rm -Rf sonarqube sonarqube-$SONAR_VERSION.zip
 mv sonarqube-$SONAR_VERSION sonarqube
 
 cd sonarqube/conf
-#sed -i 's/
-#//' sonar.properties
 sed -i "s/^#sonar.web.host.*$/sonar.web.host=$OPENSHIFT_DIY_IP/" sonar.properties
 sed -i "s/^#sonar.web.port.*$/sonar.web.port=$OPENSHIFT_DIY_PORT/" sonar.properties
 
 if [[ $PG_URL ]]
 then
-  sed -i "s/^sonar.jdbc.username.*$/sonar.jdbc.username=$OPENSHIFT_POSTGRESQL_DB_USERNAME/" sonar.properties
-  sed -i "s/^sonar.jdbc.password.*$/sonar.jdbc.password=$OPENSHIFT_POSTGRESQL_DB_PASSWORD/" sonar.properties
+  sed -i "s/^#sonar.jdbc.username.*$/sonar.jdbc.username=$OPENSHIFT_POSTGRESQL_DB_USERNAME/" sonar.properties
+  sed -i "s/^#sonar.jdbc.password.*$/sonar.jdbc.password=$OPENSHIFT_POSTGRESQL_DB_PASSWORD/" sonar.properties
   sed -i 's/^sonar.jdbc.url/#sonar.jdbc.url/' sonar.properties
   sed -i "s;^.*sonar.jdbc.url=jdbc:postgresql.*$;sonar.jdbc.url=jdbc:postgresql://$PG_URL;" sonar.properties
 fi
@@ -39,17 +37,4 @@ ln -s $OPENSHIFT_LOG_DIR logs
 cd $OPENSHIFT_DATA_DIR/tomcat
 rm -rf logs
 ln -s $OPENSHIFT_LOG_DIR logs
-
-rm ${OPENSHIFT_DATA_DIR}sonarqube/bin/linux-x86-64/lib/libwrapper-*
-rm ${OPENSHIFT_DATA_DIR}sonarqube/lib/wrapper-*
-curl -o ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz http://wrapper.tanukisoftware.com/download/3.5.9/wrapper-delta-pack-3.5.9.tar.gz
-tar -zxvf ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz -C ${OPENSHIFT_DATA_DIR}
-rm ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz
-cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/lib/wrapper.jar ${OPENSHIFT_DATA_DIR}sonarqube/lib/wrapper.jar
-cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/bin/wrapper-linux-x86-64 ${OPENSHIFT_DATA_DIR}sonarqube/bin/linux-x86-64/wrapper
-cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/lib/libwrapper-linux-x86-64.so ${OPENSHIFT_DATA_DIR}sonarqube/bin/linux-x86-64/lib/libwrapper.so
-
-echo -e "\nwrapper.backend.type=PIPE" >> ${OPENSHIFT_DATA_DIR}sonarqube/conf/wrapper.conf
-
-
 

--- a/.openshift/action_hooks/stop
+++ b/.openshift/action_hooks/stop
@@ -3,6 +3,10 @@
 ROOT=$OPENSHIFT_DATA_DIR
 
 cd $ROOT/sonarqube/bin/linux-x86-64
-./sonar.sh stop
+
+if [ -f ./sonar.sh ]
+then
+  ./sonar.sh stop
+fi
 
 


### PR DESCRIPTION
Looks like the wrapper is no longer required. Tested as working.
