### PR TITLE
Upgrade to SonarQube 5.2

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -2,12 +2,18 @@
 ROOT=$OPENSHIFT_DATA_DIR
 SONAR_VERSION=5.4
 
-# Min and max memory for sonarqube application and elastic search
-# TODO adapt for bigger gears or comment out usage bellow for defaults
-SONAR_XMX=384m
-SONAR_XMS=384m
-ELASTIC_SEARCH_XMX=128m
-ELASTIC_SEARCH_XMS=128m
+# VM Options for sonarqube web application, elastic search and compute engine processes
+# sonarqube web application: 
+# Defaults v5.6 -Xmx512m -Xms128m  -XX:MaxPermSize=160m -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true
+SONAR_WEB_OPTS="-Xmx256m -Xms128m  -XX:MaxPermSize=64m -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true"
+ 
+# compute engine:
+# Defaults v5.6      -Xmx512m -Xms128m -XX:MaxPermSize=160m -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true
+COMPUTE_ENGINE_OPTS="-Xms128m -Xms128m -XX:MaxPermSize=64m  -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true"
+
+# elastic search:
+# Defaults v5.6      -Xmx1G   -Xms256m -Xss256k -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError
+ELASTIC_SEARCH_OPTS="-Xmx128m -Xms128m -Xss256k -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError"
 
 
 # Log output of the startupscript to file
@@ -54,9 +60,11 @@ sed -i "s/^#sonar.search.port=.*$/sonar.search.port=35530/" sonar.properties
 # Also bind elasticsearch to $OPENSHIFT_DIY_IP instead of localhost
 sed -i "s/^#sonar.search.host=.*$/sonar.search.host=$OPENSHIFT_DIY_IP/" sonar.properties
 
+# Adapt java opts for running on openshift
 # If running on small gear, replace java opts for running on openshift
-sed -i "s/^#sonar.web.javaOpts=.*$/sonar.web.javaOpts=-Xmx$SONAR_XMX -Xms$SONAR_XMS/" sonar.properties
-sed -i "s/^#sonar.search.javaOpts=.*$/sonar.search.javaOpts=-Xmx$ELASTIC_SEARCH_XMX -Xms$ELASTIC_SEARCH_XMS/" sonar.properties
+sed -i "s/^#sonar.web.javaOpts=.*$/sonar.web.javaOpts=$SONAR_WEB_OPTS/" sonar.properties
+sed -i "s/^#sonar.ce.javaOpts=.*$/sonar.ce.javaOpts=$COMPUTE_ENGINE_OPTS/" sonar.properties
+sed -i "s/^#sonar.search.javaOpts=.*$/sonar.search.javaOpts=$ELASTIC_SEARCH_OPTS/" sonar.properties
 
 
 cd $OPENSHIFT_DATA_DIR

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 ROOT=$OPENSHIFT_DATA_DIR
-SONAR_VERSION=5.3
+SONAR_VERSION=5.4
 
 # Min and max memory for sonarqube application and elastic search
 # TODO adapt for bigger gears or comment out usage bellow for defaults

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,13 +1,11 @@
 #!/bin/bash
 ROOT=$OPENSHIFT_DATA_DIR
-SONAR_VERSION=5.2
+SONAR_VERSION=5.3
 
 # Min and max memory for sonarqube application and elastic search
 # TODO adapt for bigger gears or comment out usage bellow for defaults
 SONAR_XMX=384m
-SONAR_XMS=384m
 ELASTIC_SEARCH_XMX=128m
-ELASTIC_SEARCH_XMS=128m
 
 
 # Log output of the startupscript to file

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 ROOT=$OPENSHIFT_DATA_DIR
-SONAR_VERSION=4.1.1
+SONAR_VERSION=5.0
 
 # Log output of the startupscript to file
 exec > ${OPENSHIFT_DATA_DIR}logs/startup.log
@@ -35,12 +35,20 @@ sed -i "s/^#sonar.web.port.*$/sonar.web.port=$OPENSHIFT_DIY_PORT/" sonar.propert
 
 if [[ $PG_URL ]]
 then
-  sed -i "s/^sonar.jdbc.username.*$/sonar.jdbc.username=$OPENSHIFT_POSTGRESQL_DB_USERNAME/" sonar.properties
-  sed -i "s/^sonar.jdbc.password.*$/sonar.jdbc.password=$OPENSHIFT_POSTGRESQL_DB_PASSWORD/" sonar.properties
+  sed -i "s/^#sonar.jdbc.username.*$/sonar.jdbc.username=$OPENSHIFT_POSTGRESQL_DB_USERNAME/" sonar.properties
+  sed -i "s/^#sonar.jdbc.password.*$/sonar.jdbc.password=$OPENSHIFT_POSTGRESQL_DB_PASSWORD/" sonar.properties
   sed -i 's/^sonar.jdbc.url/#sonar.jdbc.url/' sonar.properties
   sed -i "s;^.*sonar.jdbc.url=jdbc:postgresql.*$;sonar.jdbc.url=jdbc:postgresql://$PG_URL;" sonar.properties
 fi
 
+# Adapt elasticsearch host to be in permitted range 15000-35530 for openshift, as specified here: https://help.openshift.com/hc/en-us/articles/202185874
+# This port is also used for the search client
+sed -i "s/^#sonar.search.port=.*$/sonar.search.port=35530/" sonar.properties
+# TODO We really could use a sonar.search.host property here, that changed the search client url
+#sed -i "s/^#sonar.search.host=.*$/sonar.search.host=$OPENSHIFT_DIY_IP/" sonar.properties
+# Workaround: Adapt elasticsearch host (address search server is bound to)
+sed -i "s/^#sonar.search.javaAdditionalOpts=.*$/sonar.search.javaAdditionalOpts=-Des.network.host=$OPENSHIFT_DIY_IP/" sonar.properties
+# What about the address the search client connects to?
 cd $OPENSHIFT_DATA_DIR
 rm -rf logs
 ln -s $OPENSHIFT_LOG_DIR logs
@@ -49,18 +57,15 @@ cd $OPENSHIFT_DATA_DIR/sonarqube
 rm -rf logs
 ln -s $OPENSHIFT_LOG_DIR logs
 
-cd $OPENSHIFT_DATA_DIR/tomcat
-rm -rf logs
-ln -s $OPENSHIFT_LOG_DIR logs
-
-rm ${OPENSHIFT_DATA_DIR}sonarqube/bin/linux-x86-64/lib/libwrapper-*
-rm ${OPENSHIFT_DATA_DIR}sonarqube/lib/wrapper-*
+rm ${OPENSHIFT_DATA_DIR}sonarqube/bin/linux-x86-64/lib/libwrapper*
+rm ${OPENSHIFT_DATA_DIR}sonarqube/lib/jsw/wrapper*
 curl -o ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz http://wrapper.tanukisoftware.com/download/3.5.9/wrapper-delta-pack-3.5.9.tar.gz
 tar -zxvf ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz -C ${OPENSHIFT_DATA_DIR}
 rm ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz
-cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/lib/wrapper.jar ${OPENSHIFT_DATA_DIR}sonarqube/lib/wrapper.jar
+cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/lib/wrapper.jar ${OPENSHIFT_DATA_DIR}sonarqube/lib/jsw/wrapper.jar
 cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/bin/wrapper-linux-x86-64 ${OPENSHIFT_DATA_DIR}sonarqube/bin/linux-x86-64/wrapper
 cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/lib/libwrapper-linux-x86-64.so ${OPENSHIFT_DATA_DIR}sonarqube/bin/linux-x86-64/lib/libwrapper.so
+rm -Rf ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/
 
 echo -e "\nwrapper.backend.type=PIPE" >> ${OPENSHIFT_DATA_DIR}sonarqube/conf/wrapper.conf
 

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,6 +1,14 @@
 #!/bin/bash
 ROOT=$OPENSHIFT_DATA_DIR
-SONAR_VERSION=5.0
+SONAR_VERSION=5.2
+
+# Min and max memory for sonarqube application and elastic search
+# TODO adapt for bigger gears or comment out usage bellow for defaults
+SONAR_XMX=384m
+SONAR_XMS=384m
+ELASTIC_SEARCH_XMX=128m
+ELASTIC_SEARCH_XMS=128m
+
 
 # Log output of the startupscript to file
 exec > ${OPENSHIFT_DATA_DIR}logs/startup.log
@@ -16,7 +24,8 @@ fi
 
 cd $ROOT
 
-wget http://dist.sonar.codehaus.org/sonarqube-$SONAR_VERSION.zip
+wget https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip
+
 unzip sonarqube-$SONAR_VERSION.zip
 rm -Rf sonarqube sonarqube-$SONAR_VERSION.zip
 mv sonarqube-$SONAR_VERSION sonarqube
@@ -26,7 +35,6 @@ cd sonarqube/conf
 #//' sonar.properties
 sed -i "s/^#sonar.web.host.*$/sonar.web.host=$OPENSHIFT_DIY_IP/" sonar.properties
 sed -i "s/^#sonar.web.port.*$/sonar.web.port=$OPENSHIFT_DIY_PORT/" sonar.properties
-
 
 # Set Wrapper log levels to debug
 #sed -i "s/^wrapper.console.loglevel.*$/wrapper.console.loglevel=DEBUG/" wrapper.conf
@@ -41,14 +49,16 @@ then
   sed -i "s;^.*sonar.jdbc.url=jdbc:postgresql.*$;sonar.jdbc.url=jdbc:postgresql://$PG_URL;" sonar.properties
 fi
 
-# Adapt elasticsearch host to be in permitted range 15000-35530 for openshift, as specified here: https://help.openshift.com/hc/en-us/articles/202185874
-# This port is also used for the search client
+# Adapt elasticsearch port to be in permitted range 15000-35530 for openshift, as specified here: https://help.openshift.com/hc/en-us/articles/202185874
 sed -i "s/^#sonar.search.port=.*$/sonar.search.port=35530/" sonar.properties
-# TODO We really could use a sonar.search.host property here, that changed the search client url
-#sed -i "s/^#sonar.search.host=.*$/sonar.search.host=$OPENSHIFT_DIY_IP/" sonar.properties
-# Workaround: Adapt elasticsearch host (address search server is bound to)
-sed -i "s/^#sonar.search.javaAdditionalOpts=.*$/sonar.search.javaAdditionalOpts=-Des.network.host=$OPENSHIFT_DIY_IP/" sonar.properties
-# What about the address the search client connects to?
+# Also bind elasticsearch to $OPENSHIFT_DIY_IP instead of localhost
+sed -i "s/^#sonar.search.host=.*$/sonar.search.host=$OPENSHIFT_DIY_IP/" sonar.properties
+
+# If running on small gear, replace java opts for running on openshift
+sed -i "s/^#sonar.web.javaOpts=.*$/sonar.web.javaOpts=-Xmx$SONAR_XMX -Xms$SONAR_XMS/" sonar.properties
+sed -i "s/^#sonar.search.javaOpts=.*$/sonar.search.javaOpts=-Xmx$ELASTIC_SEARCH_XMX -Xms$ELASTIC_SEARCH_XMS/" sonar.properties
+
+
 cd $OPENSHIFT_DATA_DIR
 rm -rf logs
 ln -s $OPENSHIFT_LOG_DIR logs
@@ -68,6 +78,3 @@ cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/lib/libwrapper-linux-x86-64.so 
 rm -Rf ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/
 
 echo -e "\nwrapper.backend.type=PIPE" >> ${OPENSHIFT_DATA_DIR}sonarqube/conf/wrapper.conf
-
-
-

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -5,7 +5,9 @@ SONAR_VERSION=5.3
 # Min and max memory for sonarqube application and elastic search
 # TODO adapt for bigger gears or comment out usage bellow for defaults
 SONAR_XMX=384m
+SONAR_XMS=384m
 ELASTIC_SEARCH_XMX=128m
+ELASTIC_SEARCH_XMS=128m
 
 
 # Log output of the startupscript to file

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -27,6 +27,12 @@ cd sonarqube/conf
 sed -i "s/^#sonar.web.host.*$/sonar.web.host=$OPENSHIFT_DIY_IP/" sonar.properties
 sed -i "s/^#sonar.web.port.*$/sonar.web.port=$OPENSHIFT_DIY_PORT/" sonar.properties
 
+
+# Set Wrapper log levels to debug
+#sed -i "s/^wrapper.console.loglevel.*$/wrapper.console.loglevel=DEBUG/" wrapper.conf
+#sed -i "s/^wrapper.logfile.loglevel.*$/wrapper.logfile.loglevel=DEBUG/" wrapper.conf
+#echo -e "\nwrapper.debug=TRUE" >> ${OPENSHIFT_DATA_DIR}sonarqube/conf/wrapper.conf
+
 if [[ $PG_URL ]]
 then
   sed -i "s/^sonar.jdbc.username.*$/sonar.jdbc.username=$OPENSHIFT_POSTGRESQL_DB_USERNAME/" sonar.properties

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -2,6 +2,13 @@
 ROOT=$OPENSHIFT_DATA_DIR
 SONAR_VERSION=4.1.1
 
+# Log output of the startupscript to file
+exec > ${OPENSHIFT_DATA_DIR}logs/startup.log
+exec 2>&1 # Also log stderr
+
+#Log the commands as well
+set -v
+
 if [[ $OPENSHIFT_POSTGRESQL_DB_URL ]]
 then
   PG_URL="$OPENSHIFT_POSTGRESQL_DB_HOST:$OPENSHIFT_POSTGRESQL_DB_PORT/$PGDATABASE"

--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -2,6 +2,8 @@
 
 ROOT=$OPENSHIFT_DATA_DIR
 
+export JAVA_HOME=/etc/alternatives/java_sdk_1.8.0
+export PATH=$JAVA_HOME/bin:$PATH
 
 
 cd $ROOT/sonarqube/bin/linux-x86-64

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ a Continuous Integration engine.
 
 More information can be found at http://www.sonarqube.org
 
-Running on OpenShift
+Running SonarQube 5.4 on OpenShift
 --------------------
 
 Create an account at http://openshift.redhat.com/
 
-For a detailed step by step introduction on how to set up SonarQube 5.2 and Jenkins with Github projects see also [here](https://itaffinity.wordpress.com/2015/11/17/building-github-projects-with-jenkins-maven-and-sonarqube-5-2-on-openshift/).
+For a detailed step by step introduction on how to set up SonarQube (for a former version - but the concepts are the same) and Jenkins with Github projects see also [here](https://itaffinity.wordpress.com/2015/11/17/building-github-projects-with-jenkins-maven-and-sonarqube-5-2-on-openshift/).
 
 Create a DIY application. If you may add a PostgreSQL cartridge.
 
@@ -20,7 +20,7 @@ Create a DIY application. If you may add a PostgreSQL cartridge.
 Add this upstream SonarQube quickstart repo
 
     git rm -r diy .openshift misc README.md
-    git remote add upstream -m master https://github.com/worldline/openshift-sonarqube.git
+    git remote add upstream -m master https://github.com/schnatterer/openshift-sonarqube
     git pull -s recursive -X theirs upstream master
 
 Push the repo upstream to OpenShift

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Running on OpenShift
 
 Create an account at http://openshift.redhat.com/
 
+For a detailed step by step introduction on how to set up SonarQube 5.2 and Jenkins with Github projects see also [here](https://itaffinity.wordpress.com/2015/11/17/building-github-projects-with-jenkins-maven-and-sonarqube-5-2-on-openshift/).
+
 Create a DIY application. If you may add a PostgreSQL cartridge.
 
     rhc app create sonar diy-0.1 postgresql-9.2


### PR DESCRIPTION
The new property [`sonar.search.host`](https://github.com/SonarSource/sonarqube/pull/124) introduced in SonarQube 5.2 allows for running SonarQube and ElasticSearch on OpenShift
